### PR TITLE
Make compatible with kitspace.org

### DIFF
--- a/kitspace.yml
+++ b/kitspace.yml
@@ -1,0 +1,1 @@
+bom: hardware/rev2/pcb/assy/cariboulite_r2_bom.xlsx


### PR DESCRIPTION
Hey, thought this would be a neat project to include over on [kitspace.org](https://kitspace.org). All that's required is to add a kitspace.yml pointing at the right BOM. If you are happy to add it, simply merge this and I'll put it up. The page will continue to update with this repo as you make changes (thought the delay can be up to 24hrs). 

Here is [a preview of what it will look like](http://add-cariboulite.preview.kitspace.org/boards/github.com/kitspace-forks/cariboulite/). The BOM could be improved a little, especially to add distributor numbers for the "Buy Parts" buttons to show up. I do have a project to help with that: [bom-builder](https://github.com/kitspace/bom-builder) ([more info](https://kitspace.org/bom-builder/)). If you would like free access to a hosted version of that, shoot me an email: kaspar@kitspace.org