### PR TITLE
docs: Fix a few typos

### DIFF
--- a/hardware/README.md
+++ b/hardware/README.md
@@ -37,7 +37,7 @@ For the first setup of the device, the write-protect pin of the EEPROM needs to 
 
 ## Clocking
 The FPGA is externally clocked by a crystal oscillator of 125MHz located in the bottom side of the board.
-Clocking the FPGA from the RPI GPCLK (GPIO4 / GPCLK0 / SMI_SA1) is also possible but not recommanded as it may cause substancial increase in the board EMI. For that reason, the GPCLK option is possible but not used in the mainline hardware version. Hacking the possibility to clock from the RPI is a good idea though.
+Clocking the FPGA from the RPI GPCLK (GPIO4 / GPCLK0 / SMI_SA1) is also possible but not recommanded as it may cause substantial increase in the board EMI. For that reason, the GPCLK option is possible but not used in the mainline hardware version. Hacking the possibility to clock from the RPI is a good idea though.
 
 The MODEM (AT86RF215) is clocked from a 26MHz TCXO (bottom layer). This device provides a stable and low phase noise clock reference to the receivers and transmitters within the IC. The MODEM further outputs a buffered version of the input clock (typically 26MHz, but other possibilities exist as well), to the MIXER input. A capacitor divider circuit adapts the LVCMOS output from the MODEM to the input levels of the MIXER.
 

--- a/software/libcariboulite/src/caribou_smi/caribou_smi.c
+++ b/software/libcariboulite/src/caribou_smi/caribou_smi.c
@@ -116,7 +116,7 @@ int caribou_smi_init(caribou_smi_st* dev)
     // the allocation is page_size rounded-up
     // The page-size if 0x1000 = (4096) decimal. Thus for a CB sized 32byte => 128 maximal number of CBs
     // Sample size from the modem is 4 bytes and each buffer contains "sample_buf_length" samples.
-    // We allocate unchahced memory for max 128 CBs and "num_sample_bufs" sample buffers
+    // We allocate uncached memory for max 128 CBs and "num_sample_bufs" sample buffers
     uint32_t single_buffer_size_round = PAGE_ROUNDUP(dev->sample_buf_length * SAMPLE_SIZE_BYTES);
     dev->videocore_alloc_size = PAGE_SIZE + dev->num_sample_bufs * single_buffer_size_round;
     dev->actual_sample_buf_length_sec = (float)(single_buffer_size_round) / 16e6;

--- a/software/libcariboulite/src/caribou_smi/ref/rpi_dma_test.c
+++ b/software/libcariboulite/src/caribou_smi/ref/rpi_dma_test.c
@@ -94,7 +94,7 @@ typedef enum {
     MEM_FLAG_HINT_PERMALOCK = 1<<6, // Likely to be locked for long periods of time
     MEM_FLAG_L1_NONALLOCATING=(MEM_FLAG_DIRECT | MEM_FLAG_COHERENT) // Allocating in L2
 } VC_ALLOC_FLAGS;
-// VC flags for unchached DMA memory
+// VC flags for uncached DMA memory
 #define DMA_MEM_FLAGS (MEM_FLAG_DIRECT|MEM_FLAG_ZERO)
 
 // Mailbox command/response structure

--- a/software/libcariboulite/src/caribou_smi/ref/rpi_dma_utils.h
+++ b/software/libcariboulite/src/caribou_smi/ref/rpi_dma_utils.h
@@ -92,7 +92,7 @@ typedef enum {
     MEM_FLAG_HINT_PERMALOCK = 1<<6, // Likely to be locked for long periods of time
     MEM_FLAG_L1_NONALLOCATING=(MEM_FLAG_DIRECT | MEM_FLAG_COHERENT) // Allocating in L2
 } VC_ALLOC_FLAGS;
-// VC flags for unchached DMA memory
+// VC flags for uncached DMA memory
 #define DMA_MEM_FLAGS (MEM_FLAG_DIRECT|MEM_FLAG_ZERO)
 
 // Mailbox command/response structure

--- a/software/libcariboulite/src/caribou_smi/register_utils.h
+++ b/software/libcariboulite/src/caribou_smi/register_utils.h
@@ -18,7 +18,7 @@
 // Union of 32-bit value with register bitfields
 #define REG_DEF(name, fields) typedef union {struct {volatile uint32_t fields;}; volatile uint32_t value;} name
 
-// VC flags for unchached DMA memory
+// VC flags for uncached DMA memory
 #define DMA_MEM_FLAGS (MEM_FLAG_COHERENT | MEM_FLAG_ZERO)
 
 

--- a/software/libcariboulite/src/io_utils/pigpio/command.c
+++ b/software/libcariboulite/src/io_utils/pigpio/command.c
@@ -870,7 +870,7 @@ int cmdParse(
 
       case 128: /* SHELL
 
-                   Two string parameters, the first space teminated.
+                   Two string parameters, the first space terminated.
                    The second arbitrary.
                 */
          f = sscanf(buf+ctl->eaten, " %*s%n %n", &n, &n2);

--- a/software/libcariboulite/src/io_utils/pigpio/command.h
+++ b/software/libcariboulite/src/io_utils/pigpio/command.h
@@ -88,7 +88,7 @@ typedef struct
 
 typedef struct
 {
-   uintptr_t p[5]; //these are sometimes converted to pointers, so presumablly they sometimes have pointers stored in them, I haven't figured out where though. --plugwash
+   uintptr_t p[5]; //these are sometimes converted to pointers, so presumably they sometimes have pointers stored in them, I haven't figured out where though. --plugwash
    int8_t opt[4];
 } cmdInstr_t;
 

--- a/software/libcariboulite/src/io_utils/pigpio/pigpio.c
+++ b/software/libcariboulite/src/io_utils/pigpio/pigpio.c
@@ -2915,7 +2915,7 @@ static uint32_t waveCbPOadr(int pos)
    page = pos/CBS_PER_OPAGE;
    slot = pos%CBS_PER_OPAGE;
 
-   //cast twice to suppress compiler warning, I belive this cast is ok
+   //cast twice to suppress compiler warning, I believe this cast is ok
    //because dmaOBus contains bus addresses, not virtual addresses.
    return (uint32_t)(uintptr_t) &dmaOBus[page]->cb[slot];
 }
@@ -2948,7 +2948,7 @@ static uint32_t waveOOLPOadr(int pos)
 
    waveOOLPageSlot(pos, &page, &slot);
 
-   //cast twice to suppress compiler warning, I belive this cast is ok
+   //cast twice to suppress compiler warning, I believe this cast is ok
    //because dmaOBus contains bus addresses, not virtual addresses.
    return (uint32_t)(uintptr_t) &dmaOBus[page]->OOL[slot];
 }
@@ -3066,7 +3066,7 @@ static int wave2Cbs(unsigned wave_mode, int *CB, int *BOOL, int *TOOL,
       p->dst  = PWM_TIMER;
    }
 
-   //cast twice to suppress compiler warning, I belive this cast is ok
+   //cast twice to suppress compiler warning, I believe this cast is ok
    //because dmaOBus contains bus addresses, not virtual addresses.
    p->src    = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
    p->length = BPD * 20 / PI_WF_MICROS; /* 20 micros delay */
@@ -3160,7 +3160,7 @@ static int wave2Cbs(unsigned wave_mode, int *CB, int *BOOL, int *TOOL,
                p->dst  = PWM_TIMER;
             }
 
-            //cast twice to suppress compiler warning, I belive this cast is ok
+            //cast twice to suppress compiler warning, I believe this cast is ok
             //because dmaOBus contains bus addresses, not virtual addresses.
             p->src = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
 
@@ -5252,7 +5252,7 @@ static unsigned dmaNowAtICB(void)
 
    while (1)
    {
-      //cast twice to suppress compiler warning, I belive this cast is ok
+      //cast twice to suppress compiler warning, I believe this cast is ok
       //because dmaIbus contains bus addresses, not user addresses. --plugwash
       cb = (cbAddr - ((int)(uintptr_t)dmaIBus[page])) / 32;
 
@@ -5296,7 +5296,7 @@ static int dmaNowAtOCB(void)
 
    while (1)
    {
-      //cast twice to suppress compiler warning, I belive this cast is ok
+      //cast twice to suppress compiler warning, I believe this cast is ok
       //because dmaIbus contains bus addresses, not user addresses. --plugwash
       cb = (cbAddr - ((int)(uintptr_t)dmaOBus[page])) / 32;
 
@@ -5317,7 +5317,7 @@ static int dmaNowAtOCB(void)
 
    while (1)
    {
-      //cast twice to suppress compiler warning, I belive this cast is ok
+      //cast twice to suppress compiler warning, I believe this cast is ok
       //because dmaIbus contains bus addresses, not user addresses. --plugwash
       cb = (cbAddr - ((int)(uintptr_t)dmaOBus[page])) / 32;
 
@@ -5348,7 +5348,7 @@ unsigned rawWaveCB(void)
 
    while (1)
    {
-      //cast twice to suppress compiler warning, I belive this cast is ok
+      //cast twice to suppress compiler warning, I believe this cast is ok
       //because dmaIbus contains bus addresses, not user addresses. --plugwash
       cb = (cbAddr - ((int)(uintptr_t)dmaOBus[page])) / 32;
 
@@ -5385,7 +5385,7 @@ static unsigned dmaCurrentSlot(unsigned pos)
 
 static uint32_t dmaPwmDataAdr(int pos)
 {
-   //cast twice to suppress compiler warning, I belive this cast is ok
+   //cast twice to suppress compiler warning, I believe this cast is ok
    //because dmaIbus contains bus addresses, not user addresses. --plugwash
    return (uint32_t)(uintptr_t) &dmaIBus[pos]->periphData;
 }
@@ -5399,7 +5399,7 @@ static uint32_t dmaGpioOnAdr(int pos)
    page = pos/ON_PER_IPAGE;
    slot = pos%ON_PER_IPAGE;
 
-   //cast twice to suppress compiler warning, I belive this cast is ok
+   //cast twice to suppress compiler warning, I believe this cast is ok
    //because dmaIbus contains bus addresses, not user addresses. --plugwash
    return (uint32_t)(uintptr_t) &dmaIBus[page]->gpioOn[slot];
 }
@@ -5412,7 +5412,7 @@ static uint32_t dmaGpioOffAdr(int pos)
 
    myOffPageSlot(pos, &page, &slot);
 
-   //cast twice to suppress compiler warning, I belive this cast is ok
+   //cast twice to suppress compiler warning, I believe this cast is ok
    //because dmaIbus contains bus addresses, not user addresses. --plugwash
    return (uint32_t)(uintptr_t) &dmaIBus[page]->gpioOff[slot];
 }
@@ -5425,7 +5425,7 @@ static uint32_t dmaTickAdr(int pos)
 
    myTckPageSlot(pos, &page, &slot);
 
-   //cast twice to suppress compiler warning, I belive this cast is ok
+   //cast twice to suppress compiler warning, I believe this cast is ok
    //because dmaIbus contains bus addresses, not user addresses. --plugwash
    return (uint32_t)(uintptr_t) &dmaIBus[page]->tick[slot];
 }
@@ -5438,7 +5438,7 @@ static uint32_t dmaReadLevelsAdr(int pos)
 
    myLvsPageSlot(pos, &page, &slot);
 
-   //cast twice to suppress compiler warning, I belive this cast is ok
+   //cast twice to suppress compiler warning, I believe this cast is ok
    //because dmaIbus contains bus addresses, not user addresses. --plugwash
    return (uint32_t)(uintptr_t) &dmaIBus[page]->level[slot];
 }
@@ -5452,7 +5452,7 @@ static uint32_t dmaCbAdr(int pos)
    page = (pos/CBS_PER_IPAGE);
    slot = (pos%CBS_PER_IPAGE);
 
-   //cast twice to suppress compiler warning, I belive this cast is ok
+   //cast twice to suppress compiler warning, I believe this cast is ok
    //because dmaIbus contains bus addresses, not user addresses. --plugwash
    return (uint32_t)(uintptr_t) &dmaIBus[page]->cb[slot];
 }
@@ -6355,7 +6355,7 @@ static void * pthAlertThread(void *x)
 
             dmaInitCbs();
             flushMemory();
-            //cast twice to suppress compiler warning, I belive this cast is ok
+            //cast twice to suppress compiler warning, I believe this cast is ok
             //because dmaIbus contains bus addresses, not user addresses. --plugwash
             initDMAgo((uint32_t *)dmaIn, (uint32_t)(uintptr_t)dmaIBus[0]);
             myGpioDelay(5000); /* let DMA run for a while */
@@ -7502,7 +7502,7 @@ static int initZaps
 
       if (physical)
       {
-         //cast twice to suppress warning, I belive this is ok as these
+         //cast twice to suppress warning, I believe this is ok as these
          //are bus addresses, not virtual addresses. --plugwash
          dmaBus[basePage+n] = (dmaPage_t *)(uintptr_t) (physical | pi_dram_bus);
 
@@ -8444,7 +8444,7 @@ int initInitialise(void)
 
    flushMemory();
 
-   //cast twice to suppress compiler warning, I belive this cast
+   //cast twice to suppress compiler warning, I believe this cast
    //is ok because dmaIBus contains bus addresses, not virtual
    //addresses.
    initDMAgo((uint32_t *)dmaIn, (uint32_t)(uintptr_t)dmaIBus[0]);
@@ -9982,7 +9982,7 @@ static uint32_t chainGetValPadr(int n)
       block = n / WCB_CHAIN_OOL;
       index = n % WCB_CHAIN_OOL;
       p = (uint32_t *) dmaOBus[block] + (WCB_COUNTER_CBS+WCB_CHAIN_CBS) * 8;
-      //cast twice to suppress warning, I belive this is ok as dmaOBus
+      //cast twice to suppress warning, I believe this is ok as dmaOBus
       //contains bus addresses not virtual addresses.
       return (uint32_t)(uintptr_t) (p + index);
    }
@@ -10016,7 +10016,7 @@ static uint32_t chainGetCntValPadr(int counter, int slot)
    page = counter / 2;
    offset = (counter % 2 ? WCB_COUNTER_OOL : 0);
    p = (uint32_t *) dmaOBus[page] + (WCB_COUNTER_CBS+WCB_CHAIN_CBS) * 8;
-   //cast twice to suppress warning, I belive this is ok as dmaOBus
+   //cast twice to suppress warning, I believe this is ok as dmaOBus
    //contains bus addresses not virtual addresses. --plugwash
    return (uint32_t)(uintptr_t)(p + WCB_CHAIN_OOL + offset + slot);
 }
@@ -10176,7 +10176,7 @@ int gpioWaveChain(char *buf, unsigned bufSize)
       p->dst  = PWM_TIMER;
    }
 
-   //cast twice to suppress warning, I belive this is ok as dmaOBus
+   //cast twice to suppress warning, I believe this is ok as dmaOBus
    //contains bus addresses not virtual addresses. --plugwash
    p->src    = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
    p->length = BPD * 20 / PI_WF_MICROS; /* 20 micros delay */
@@ -10268,7 +10268,7 @@ int gpioWaveChain(char *buf, unsigned bufSize)
 
                /* dummy src and dest */
                p->info = NORMAL_DMA;
-               //cast twice to suppress warning, I belive this is ok as dmaOBus
+               //cast twice to suppress warning, I believe this is ok as dmaOBus
                //contains bus addresses not virtual addresses. --plugwash
                p->src = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
                p->dst = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
@@ -10322,7 +10322,7 @@ int gpioWaveChain(char *buf, unsigned bufSize)
                      p->dst  = PWM_TIMER;
                   }
 
-                  //cast twice to suppress warning, I belive this is ok as dmaOBus
+                  //cast twice to suppress warning, I believe this is ok as dmaOBus
                   //contains bus addresses not virtual addresses. --plugwash
                   p->src = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
 
@@ -10363,7 +10363,7 @@ int gpioWaveChain(char *buf, unsigned bufSize)
 
             /* dummy src and dest */
             p->info = NORMAL_DMA;
-            //cast twice to suppress warning, I belive this is ok as dmaOBus
+            //cast twice to suppress warning, I believe this is ok as dmaOBus
             //contains bus addresses not virtual addresses. --plugwash
             p->src = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
             p->dst = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
@@ -10414,7 +10414,7 @@ int gpioWaveChain(char *buf, unsigned bufSize)
 
    p->info   = NORMAL_DMA;
 
-   //cast twice to suppress warning, I belive this is ok as dmaOBus
+   //cast twice to suppress warning, I believe this is ok as dmaOBus
    //contains bus addresses not virtual addresses. --plugwash
    p->src    = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
    p->dst    = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);

--- a/software/libcariboulite/src/io_utils/pigpio/pigpio.h
+++ b/software/libcariboulite/src/io_utils/pigpio/pigpio.h
@@ -5109,7 +5109,7 @@ D*/
 /*F*/
 rawCbs_t *rawWaveCBAdr(int cbNum);
 /*D
-Return the (Linux) address of contol block cbNum.
+Return the (Linux) address of control block cbNum.
 
 . .
 cbNum: the cb of interest
@@ -5361,7 +5361,7 @@ An 8-bit byte value.
 
 cbNum::
 
-A number identifying a DMA contol block.
+A number identifying a DMA control block.
 
 cfgMicros::
 


### PR DESCRIPTION
There are small typos in:
- hardware/README.md
- software/libcariboulite/src/caribou_smi/caribou_smi.c
- software/libcariboulite/src/caribou_smi/ref/rpi_dma_test.c
- software/libcariboulite/src/caribou_smi/ref/rpi_dma_utils.h
- software/libcariboulite/src/caribou_smi/register_utils.h
- software/libcariboulite/src/io_utils/pigpio/command.c
- software/libcariboulite/src/io_utils/pigpio/command.h
- software/libcariboulite/src/io_utils/pigpio/pigpio.c
- software/libcariboulite/src/io_utils/pigpio/pigpio.h

Fixes:
- Should read `believe` rather than `belive`.
- Should read `uncached` rather than `unchached`.
- Should read `control` rather than `contol`.
- Should read `uncached` rather than `unchahced`.
- Should read `terminated` rather than `teminated`.
- Should read `substantial` rather than `substancial`.
- Should read `presumably` rather than `presumablly`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md