### PR TITLE
[Build] Install libiir as required by SoapyCariboulite

### DIFF
--- a/software/libcariboulite/CMakeLists.txt
+++ b/software/libcariboulite/CMakeLists.txt
@@ -25,7 +25,7 @@ add_subdirectory(src/cariboulite_config EXCLUDE_FROM_ALL)
 add_subdirectory(src/cariboulite_eeprom EXCLUDE_FROM_ALL)
 add_subdirectory(src/production_utils EXCLUDE_FROM_ALL)
 add_subdirectory(src/zf_log EXCLUDE_FROM_ALL)
-add_subdirectory(src/iir EXCLUDE_FROM_ALL)
+add_subdirectory(src/iir)
 
 # Create the library LibCaribouLite
 add_library(cariboulite STATIC ${SOURCES_LIB})


### PR DESCRIPTION
After doing a `make install` in `software/cariboulite/`'s build folder it installs the SoapyCariboulite module but not the libiir.so file on which it depends. With this micro-patch it will install libiir so it is possible to probe the device with `SoapySDRUtil --probe` or `--find`.