### PR TITLE
Fix swapped S1G and HiF channels in SoapySDR API

### DIFF
--- a/software/libcariboulite/src/soapy_api/Cariboulite.cpp
+++ b/software/libcariboulite/src/soapy_api/Cariboulite.cpp
@@ -16,11 +16,11 @@ Cariboulite::Cariboulite(const SoapySDR::Kwargs &args)
 
 	if (!args.at("channel").compare ("HiF"))
 	{	
-        radio = &sess.sys.radio_low;
+        radio = &sess.sys.radio_high;
 	}
 	else if (!args.at("channel").compare ("S1G"))
 	{
-        radio = &sess.sys.radio_high;
+        radio = &sess.sys.radio_low;
 	}
 	else
 	{


### PR DESCRIPTION

This change fixes the problem of the wrong channel used in the following
configuration:

- sdrpp --server running on a Raspberry Pi with the CaribouLite hat installed.
- sdrpp client running on a remote computer, connecting to the sdrpp server
  on the Raspberry Pi.
- Selecting HiF device in the SDR++ client and starting the reception will
  actually activate the S1G channel. This can be seen from the status LED on
  the board, and from the fact that there is no signal received until an
  antenna is attached to the S1G SMA connector.

It also fixes the wrong antenna reported by the SigDigger: before this fix
choosing HiF device would display antenna as S1G and vice versa.