### PR TITLE
Fix compilation error with undefined shared_ptr

### DIFF
--- a/software/libcariboulite/src/CaribouLite.hpp
+++ b/software/libcariboulite/src/CaribouLite.hpp
@@ -20,6 +20,7 @@
 #include <ostream>
 #include <iostream>
 #include <thread>
+#include <memory>
 #include <mutex>
 #include <functional>
 


### PR DESCRIPTION
`std::shared_ptr` requires `<memory>` header. Without it being included explicitly some compilers might fail to compile (while others might have been using the header indirectly).

Fixes compilation error with GCC 12 on Raspberry Pi OS.