### PR TITLE
Fix detection of linux headers on Raspberry Pi OS

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -16,7 +16,9 @@ execute_process(
 # Find the headers
 find_path(
         KERNELHEADERS_DIR
-        include/linux/user.h
+        NAMES
+            include/linux/user.h
+            include/generated/autoconf.h
         PATHS /usr/src/linux-headers-${KERNEL_RELEASE}
 )
 


### PR DESCRIPTION
On the Raspberry Pi OS the Linux headers are split into multiple packages and directories under /usr/src: the configuration and actual header files are in different packages. Presumably, this is done this way to allow re-using the header files of the same kernel by all Raspberry Pi kernel flavors.

This made the logic before this change to not consider valid linux headers directory be so: /usr/src/linux-headers-${KERNEL_RELEASE} does not contain include/linux/user.h.

Tweak the code so that it additionally considers directories which contains include/generated/autoconf.h to be kernel headers directory. This file is checked by the linux header's directory Makefile and it is not found the kernel configuration is considered invalid. This path sees to be hardcoded, so it should be the same on all platforms.