### PR TITLE
Fix driver's install.sh + warn not in use

### DIFF
--- a/driver/install.sh
+++ b/driver/install.sh
@@ -56,7 +56,7 @@ install() {
     fi
 
     if [[ ! $output_dir == *`uname -r`* ]]; then
-        printf "${CYAN}Warning: Not installing to currently operating kernel version\n"
+        printf "${CYAN}Warning: Not installing to currently operating kernel version.${NC}\n"
     fi
     
     printf "\n[  3  ] ${GREEN}Installing into '${output_dir}'${NC}\n"

--- a/driver/install.sh
+++ b/driver/install.sh
@@ -57,8 +57,12 @@ install() {
 
     printf "\n[  3  ] ${GREEN}Installing into '${output_dir}'${NC}\n"
     xz -z ${ROOT_DIR}/$BUILD_DIR/smi_stream_dev.ko -c > ${ROOT_DIR}/$BUILD_DIR/smi_stream_dev.ko.xz
-    sudo cp -r ${ROOT_DIR}/$BUILD_DIR/smi_stream_dev.ko.xz ${output_dir}/
 
+    for dir in $output_dir; do
+        sudo cp ${ROOT_DIR}/$BUILD_DIR/smi_stream_dev.ko.xz $dir
+    done
+        
+        
     printf "\n[  4  ] ${GREEN}Updating 'depmod'${NC}\n"
     sudo depmod -a
 

--- a/driver/install.sh
+++ b/driver/install.sh
@@ -59,7 +59,7 @@ install() {
     xz -z ${ROOT_DIR}/$BUILD_DIR/smi_stream_dev.ko -c > ${ROOT_DIR}/$BUILD_DIR/smi_stream_dev.ko.xz
 
     for dir in $output_dir; do
-        sudo cp ${ROOT_DIR}/$BUILD_DIR/smi_stream_dev.ko.xz $dir
+        sudo cp ${ROOT_DIR}/$BUILD_DIR/smi_stream_dev.ko.xz $dir/
     done
         
         

--- a/driver/install.sh
+++ b/driver/install.sh
@@ -55,6 +55,10 @@ install() {
         exit 100
     fi
 
+    if [[ ! $output_dir == *`uname -r`* ]]; then
+        printf "${CYAN}Warning: Not installing to currently operating kernel version\n"
+    fi
+    
     printf "\n[  3  ] ${GREEN}Installing into '${output_dir}'${NC}\n"
     xz -z ${ROOT_DIR}/$BUILD_DIR/smi_stream_dev.ko -c > ${ROOT_DIR}/$BUILD_DIR/smi_stream_dev.ko.xz
 


### PR DESCRIPTION
cp can't copy multiple directories in a single line. Used for loop instead.

Still install for every kernel version that the bcm driver is found under.

Also add warning if it isn't going to be installed under the kernel in use.

#134 