### PR TITLE
[EXPERIMENTAL] CW TX working with SoapySDR API / Fixed Wrong streamWrite function…

### DIFF
--- a/software/libcariboulite/src/soapy_api/Cariboulite.hpp
+++ b/software/libcariboulite/src/soapy_api/Cariboulite.hpp
@@ -83,13 +83,14 @@ public:
                         int &flags,
                         long long &timeNs,
                         const long timeoutUs = 100000);
-                        
+
+        // writeStream signature is different from readStream!!                
         int writeStream(SoapySDR::Stream *stream,
-                        void * const *buffs,
+                        const void * const *buffs, // const first!
                         const size_t numElems,
                         int &flags,
-                        long long &timeNs,
-                        const long timeoutUs);
+                        const long long timeNs = 0, // const first, don't pass as reference !
+                        const long timeoutUs = 100000); // default value ?
 
         /*******************************************************************
          * Antenna API

--- a/software/libcariboulite/src/soapy_api/CaribouliteStream.cpp
+++ b/software/libcariboulite/src/soapy_api/CaribouliteStream.cpp
@@ -7,7 +7,8 @@
 #define NUM_BYTES_PER_CPLX_ELEM         ( sizeof(cariboulite_sample_complex_int16) )
 #define NUM_NATIVE_MTUS_PER_QUEUE		( 10 )
 
-#define USE_ASYNC                       ( 1 )
+// Undefine to also use TX
+//#define USE_ASYNC                       ( 1 )
 #define USE_ASYNC_OVERRIDE_WRITES       ( true )
 #define USE_ASYNC_BLOCK_READS           ( true )
 
@@ -260,8 +261,8 @@ int SoapySDR::Stream::Read(cariboulite_sample_complex_int16 *buffer, size_t num_
 {
     #if USE_ASYNC
         return rx_queue->get(buffer, num_samples, timeout_us);
-    #else
-        int ret = cariboulite_radio_read_samples(radio, buffer, (caribou_smi_sample_meta*)meta, num_samples);
+    #else                                                        // caribou_smi_sample_meta not defined...
+        int ret = cariboulite_radio_read_samples(radio, buffer, (cariboulite_sample_meta*)meta, num_samples);
         if (ret < 0)
         {
             if (ret == -1)

--- a/software/libcariboulite/src/soapy_api/CaribouliteStreamFunctions.cpp
+++ b/software/libcariboulite/src/soapy_api/CaribouliteStreamFunctions.cpp
@@ -116,7 +116,24 @@ SoapySDR::Stream *Cariboulite::setupStream(const int direction,
 
     stream->setInnerStreamType(direction == SOAPY_SDR_TX ? cariboulite_channel_dir_tx : cariboulite_channel_dir_rx);
     
+    // Default: CW Output -> OFF
 	cariboulite_radio_set_cw_outputs(radio, false, false);
+
+    // Check if args has CW Output -> ON/OFF
+    for(auto it = args.cbegin(); it != args.cend(); ++it)
+    {   
+        if(!it->first.compare("CW") && !it->second.compare("1")) // "CW=1"
+        { // SET CW ON
+            SoapySDR_logf(SOAPY_SDR_INFO, "CW Output: ON\n");
+            cariboulite_radio_set_cw_outputs(radio, false, true);
+        }
+        else if(!it->first.compare("CW") && !it->second.compare("0")) // "CW=0"
+        { // SET CW OFF
+            SoapySDR_logf(SOAPY_SDR_INFO, "CW Output: OFF\n");
+            cariboulite_radio_set_cw_outputs(radio, false, false);
+        }
+    }
+
     cariboulite_radio_activate_channel(radio, stream->getInnerStreamType(), false);
     return stream;
 }
@@ -258,10 +275,10 @@ int Cariboulite::readStream(
      */
 int Cariboulite::writeStream(
             SoapySDR::Stream *stream,
-            void * const *buffs,
+            const void * const *buffs, // const void* !!
             const size_t numElems,
             int &flags,
-            long long &timeNs,
+            const long long timeNs, // const long long !!
             const long timeoutUs)
 {
 	// Verify that it is an TX stream


### PR DESCRIPTION
Hi! I was experimenting with the SoapySDR Api trying to run the python example ```soapy_syth.py``` and gnuradio's custom sink with Cariboulite. They both generate the -5 error code (not implemented) after some investigation it turned out the streamWrite function had some differences from the SoapySDR virtual prototype! I also enabled CW generator when the args are set to "CW=1"... Hope it helps! The streamWrite function now works, but the IQ data doesn't get transmitted tought (Not sure where is the problem I've digged into the smi code and everything seems to return ok, but the tx led never goes on...)

Tested with:
RaspberryPi 4B
Cariboulite R2.8 6GHz.
Raspbian OS 64bit
SoapySDR 0.8.1