### PR TITLE
Update smi_stream_dev.c

### DIFF
--- a/driver/smi_stream_dev.c
+++ b/driver/smi_stream_dev.c
@@ -1316,7 +1316,7 @@ static int smi_stream_dev_probe(struct platform_device *pdev)
 	}
 
 	// Create sysfs entries with "smi-stream-dev"
-	smi_stream_class = class_create(THIS_MODULE, DEVICE_NAME);
+	smi_stream_class = class_create(DEVICE_NAME);
 	ptr_err = smi_stream_class;
 	if (IS_ERR(ptr_err))
 	{


### PR DESCRIPTION
This fixes building on DragonOS_Pi64 - not sure if it breaks other OSes or not, though.

/home/ubuntu/cariboulite/driver/build/smi_stream_dev.c:1319:28: error: too many arguments to function ‘class_create’
 1319 |         smi_stream_class = class_create(THIS_MODULE, DEVICE_NAME);