### PR TITLE
Fix issues adding Ubuntu users to dialout, root groups

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -35,13 +35,7 @@ sudo apt-get -y install swig avahi-daemon libavahi-client-dev python3-distutils 
 if grep -iq "NAME=\"Ubuntu\"" /etc/os-release; then
 	sudo apt-get install rpi.gpio-common
 	echo "Adding user `whoami` to dialout, root groups"
-	
-	if [[ "`groups ``whoami`" == *`whoami`* ]]; then
-	   echo "`   User already in the group`" 
-	else
-	   sudo usermod -aG dialout, root "${USER}"
-	fi
-	
+	sudo usermod -aG dialout,root "${USER}"
 fi
 
 sudo depmod -a


### PR DESCRIPTION
the echo in the first half of 'if' had back-ticks causing execution instead of just text, but the whole statement isn't needed because re-adding the user to the group is a no-op, anyway.  space within the usermod command was causing it to fail also.