### PR TITLE
Update install.sh to handle `/boot/firmware/config.txt` as well on Raspberry Pi OS Bookworm.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -143,6 +143,9 @@ sudo ldconfig
 ## Configuration File - RPI /boot/config.txt
 ## --------------------------------------------------------------------
 CONFIG_TXT_PATH="/boot/config.txt"
+if [ -f "/boot/firmware/config.txt" ]; then
+	CONFIG_TXT_PATH="/boot/firmware/config.txt"
+fi
 if grep -iq "NAME=\"Ubuntu\"" /etc/os-release; then
 	CONFIG_TXT_PATH="/boot/firmware/config.txt"
 fi


### PR DESCRIPTION
Answers #209 by checking for the `/boot/firmware/config.txt` existence, and if found, setting `CONFIG_TXT_PATH` to it.