### PR TITLE
Fixing SMI Driver Issue RaspberryPi OS: Bookworm (64bit)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@
 *.su
 *.idb
 *.pdb
+*.log
 
 # Kernel Module Compile Results
 *.mod*

--- a/ADDITIONAL-README.md
+++ b/ADDITIONAL-README.md
@@ -1,0 +1,406 @@
+#Install CaribouLite with Raspberry Pi OS Bookworm (Lite) (64bit)
+
+My goal is to install the cariboulite on a Raspberry Pi0_2W and/or a Pi4. Requirements:  
+- Connecetd to the Pi over etehernet and ultimately provide power to the Pi with POE  
+- Use SDR++ server and SDR++  
+- Use gnu-radio
+
+All of the software fits on a sdcard of 16GByte. The CarubouLite uses SoapySDR as an hardware abstraction layer and needs to be installed as well. This can be done manually or automatically with the CaribouLite install script.
+
+This 'recipe' was create and tested on a Pi0 and a Pi4 on May 1st 2025.  
+ 
+###Initial steps
+Download & install the latest version of PiOS using the Raspberry Pi Imager. Ensure that you have enabled ssh under services and that you have provided basic information to the general settings of the OS Customisation.  
+
+I make the assumption that all of this is familiar to you and you know how to ssh over the local network to your Pi and know how to work with nano the text editor.
+
+After you have logged on, update the Pi OS:
+
+```
+sudo apt upate
+sudo apt upgrade
+```
+###Modifying the boot config.txt file
+Modify the `/boot/firmware/config.txt` file to ensure the parameters are set so that the cariboulite can communicate with the CPU. The last two lines disable Bluetooth and WiFi, to minimise RF interference. So the Pi needs to be connected to the local network through an ethernet cable, else you can no longer communicate with the Pi after the next reboot. 
+
+`sudo nano /boot/firmware/config.txt`
+
+Add the lines below just above the line that reads:   
+`# Enable audio (loads snd_bcm2835)`
+
+```
+dtparam=i2c_arm=off
+dtparam=spi=off
+
+# CaribouLite
+dtparam=i2c_vc=on
+dtoverlay=spi1-3cs
+
+# Disable WiFi and Bluetooth
+dtoverlay=disable-wifi
+dtoverlay=disable-bt
+```
+
+Save the file and reboot
+
+###Install linux kernel header files:
+
+```sudo apt install linux-headers-rpi-v8```
+>Note: I think this step is only required if you want build SDR++.
+
+###Monitoring the Pi's activity
+The next steps will often take a while, during which you might want to periodically check that everything is still moving along.
+In separate terminals watch what is going on during any of the following steps with `htop` and/or `dmesg`. This is how I discovered that `make` ran out of memory. 
+
+```
+htop
+sudo dmesg -wH
+```
+###Install `git` & `cmake`
+
+```
+sudo apt install git cmake
+```
+
+#SoapySDR (optional)
+If you want to have more control over where SoapySDR en SoapyRemote are installed, execute these steps first. If you use these steps, you should say `No` to the `install SoapySDR` question from the CaribouLite install script.
+
+Get the source code:
+
+```
+git clone https://github.com/pothosware/SoapySDR.git
+git clone https://github.com/pothosware/Soapyremote.git
+
+```
+Or:
+
+```
+git clone https://github.com/Habraken/SoapySDR.git
+git clone https://github.com/Habraken/SoapyRemote.git
+```
+
+In both repositories runs the below commands to build and install SoapySDR and SoapyRemote starting with SoapySDR as SoapyRemote depends on it.
+
+```
+mkdir build && cd build
+cmake ..
+make -j`nproc`
+sudo make install -j`nproc`
+sudo ldconfig #needed on debian systems
+SoapySDRUtil --info
+```
+
+#CaribouLite
+Create a directory where you want to keep your source code. I call mine: `src`. 
+
+```
+mkdir src && cd src
+``` 
+
+Get the source code:
+
+```
+git clone https://github.com/cariboulabs/cariboulite.git
+```
+
+Or if you don't want to patch yourself:
+
+```
+git clone https://github.com/Habraken/cariboulite.git
+```
+
+Before you can install anything make the following three changes to `~/src/cariboulite/driver/smi_stream_dev.c`.
+
+```
+cd ~/src/cariboulite/driver
+sudo nano smi_stream_dev.c
+```
+
+Add this include statement near the other include statements: `#include <linux/vmalloc.h>`
+
+Then Hit Ctl+W and type `‘create sysfs’` and change the line with the `-` in front to the line with the `+` in front.
+
+```
+// Create sysfs entries with "smi-stream-dev"
+-smi_stream_class = class_create(THIS_MODULE, DEVICE_NAME);
++smi_stream_class = class_create(DEVICE_NAME);
+```
+
+Then Hit Ctl+W and type ‘smi_stream_dev_remove’ and change the line with the - in front to the line with the + in front and remove the return statement with the - in front.
+
+```
+*   smi_stream_remove - called when the driver is unloaded.
+*
+***************************************************************************/
+ 
+-static int smi_stream_dev_remove(struct platform_device *pdev)
++static void smi_stream_dev_remove(struct platform_device *pdev)
+ {
+     //if (inst->reader_thread != NULL) kthread_stop(inst->reader_thread);
+     //inst->reader_thread = NULL;	
+     
+     device_destroy(smi_stream_class, smi_stream_devid);
+     class_destroy(smi_stream_class);
+     cdev_del(&smi_stream_cdev);
+     unregister_chrdev_region(smi_stream_devid, 1);
+ 
+     dev_info(inst->dev, DRIVER_NAME": smi-stream dev removed");
+-    return 0;
+ }
+```
+
+In the `cariboulite/driver` directory:
+
+```
+./install.sh install
+```
+
+Then in the cariboulite directory:
+
+```
+./install.sh
+```
+This takes ‘a while’ on a Pi0. At a certain point the script will ask if you want to `install SoapySDR`, if you did not install it before. Say `Yes`. After the script has completed, reboot the Pi. Now we need to check with SMI driver is working correctly.
+
+```
+lsmod | grep smi
+```
+The ouput should look like this:
+
+```
+pi@pi0b-bookworm:~ $ lsmod | grep smi
+smi_stream_dev         16384  0
+bcm2835_smi            20480  1 smi_stream_dev
+pi@pi0b-bookworm:~ $ 
+```
+Also check if the permissions are set correclty:
+
+```
+ls -l /dev/smi
+```
+the ouput shoudl look like this:
+
+```
+pi@pi0b-bookworm:~ $ ls -l /dev/smi
+crw-rw-rw- 1 root root 239, 0 May  1 13:40 /dev/smi
+pi@pi0b-bookworm:~ $ 
+```
+
+###Testing SoapySDR
+
+As SoapySDR was install by the install script of cariboulite it should be possible to communicate with the CaribouLite.
+
+```
+SoapySDRUtil --find
+``` 
+The ouput should look like this:
+
+```
+######################################################
+##     Soapy SDR -- the SDR abstraction library     ##
+######################################################
+
+[INFO] SoapyCaribouliteSession, sessionCount: 0
+05-01 13:51:14.339   627   627 I CARIBOU_PROG caribou_prog_configure_from_buffer@caribou_prog.c:260 Sending bitstream of size 32220
+05-01 13:51:16.644   627   627 I CARIBOU_PROG caribou_prog_configure_from_buffer@caribou_prog.c:292 FPGA programming - Success!
+
+Printing 'findCariboulite' Request:
+Found device 0
+  channel = S1G
+  device_id = 0
+  driver = Cariboulite
+  label = CaribouLite S1G[1e3bc7c2]
+  name = CaribouLite RPI Hat
+  serial = 1e3bc7c2
+  uuid = 11884996-87f4-4b07-9961-a38c1b78fa08
+  vendor = CaribouLabs LTD
+  version = 0x0001
+
+Found device 1
+  channel = HiF
+  device_id = 1
+  driver = Cariboulite
+  label = CaribouLite HiF[1e3bc7c3]
+  name = CaribouLite RPI Hat
+  serial = 1e3bc7c3
+  uuid = 11884996-87f4-4b07-9961-a38c1b78fa08
+  vendor = CaribouLabs LTD
+  version = 0x0001
+```
+
+Now it is also possible to interact with the CaribouLite board with the provided `cariboulite_test_app` in the `~/src/cariboulite/build` directory.
+
+```
+./cariboulite_test_app
+```
+At the end of a lot of ouput there should be something like this:
+
+```
+
+	   ____           _ _                 _     _ _         
+	  / ___|__ _ _ __(_) |__   ___  _   _| |   (_) |_ ___   
+	 | |   / _` | '__| | '_ \ / _ \| | | | |   | | __/ _ \  
+	 | |__| (_| | |  | | |_) | (_) | |_| | |___| | ||  __/  
+	  \____\__,_|_|  |_|_.__/ \___/ \__,_|_____|_|\__\___|  
+
+
+ Select a function:
+ [0]  Hard reset FPGA
+ [1]  Soft reset FPGA
+ [2]  Print board info and versions
+ [3]  Program FPGA
+ [4]  Perform a Self-Test
+ [5]  FPGA Digital I/O
+ [6]  FPGA RFFE control
+ [7]  FPGA SMI fifo status
+ [8]  Modem transmit CW signal
+ [9]  Modem receive I/Q stream
+ [10]  Synthesizer 85-4200 MHz
+ [99]  Quit
+    Choice:
+```
+>Note: I you try option `9` and then select option `2` there will errors that look like this:
+>
+```
+FF D0 FF F4 FF 02 C0 D8  FF C0 FF FC FF C2 FF E6  |  ................ 
+05-01 14:00:45.038   644   648 E CARIBOULITE Radio cariboulite_radio_read_samples@cariboulite_radio.c:1276 SMI data synchronization failed
+FF E0 FF D2 C0 12 C0 1A  C0 DA FF 02 C0 00 C0 EE  |  ................ 
+05-01 14:00:45.046   644   648 E CARIBOULITE Radio cariboulite_radio_read_samples@cariboulite_radio.c:1276 SMI data synchronization failed
+C0 C0 C0 C4 C0 FA C0 E6  C0 30 C0 22 C0 C0 C0 CC  |  .........0.".... 
+05-01 14:00:45.055   644   648 E CARIBOULITE Radio cariboulite_radio_read_samples@cariboulite_radio.c:1276 SMI data synchronization failed
+```
+This is caused by the Pi0 not beeing able to handle 4 MSPS. During the configuration of SoapyRemote or SDR++ server we shall chnage this to 2 MSPS. 
+
+###Increase the swapfile size
+During the SDR++ build `make` ran out of memory. Hence I increased the swap file from 512 to 1024.
+
+```
+sudo dphys-swapfile swapoff  
+sudo nano /etc/dphys-swapfile 
+```
+Chnage the line `CONF_SWAPSIZE=512` to `CONF_SWAPSIZE=1024`. Save the file.
+
+```
+sudo dphys-swapfile setup
+sudo dphys-swapfile swapon  
+```
+
+Or:
+
+```
+sudo reboot
+```
+#SDR++
+
+Install dependencies for SDR++:
+
+```
+sudo apt install libglfw3 // maybe  not needed.
+sudo apt install libglfw3-dev
+sudo apt install libfftw3-dev
+sudo apt install libvolk2-dev
+sudo apt install libzstd-dev
+sudo apt install librtaudio-dev
+```
+
+or in one go:
+
+```
+sudo apt install libglfw3-dev libfftw3-dev libvolk2-dev libzstd-dev librtaudio-dev
+
+```
+### Install via the nightly build package
+
+The easiest method is to download and install the nightly builds of SDR++. First download the package:
+
+```
+curl https://github.com/AlexandreRouma/SDRPlusPlus/releases/download/nightly/sdrpp_debian_bookworm_aarch64.deb
+```
+
+Then run the following:
+
+```
+sudo apt install ~/Downloads/sdrpp_debian_bookworm_aarch64.db
+```
+
+### Build from source
+
+Get the source code:
+
+```
+git clone https://github.com/AlexandreRouma/SDRPlusPlus.git
+```
+
+```
+git clone https://github.com/Habraken/SDRPlusPlus.git
+```
+In the `~/src/SDRPlusPLus` directory:
+
+```
+mkdir build && cd build
+```
+
+```
+cmake  -DOPT_BUILD_SOAPY_SOURCE=ON -DOPT_BUILD_HERMES_SOURCE=ON -DOPT_BUILD_PLUTOSDR_SOURCE=OFF -DOPT_BUILD_AIRSPY_SOURCE=OFF -DOPT_BUILD_AIRSPYHF_SOURCE=OFF -DOPT_BUILD_HACKRF_SOURCE=OFF -DOPT_BUILD_RTL_SDR_SOURCE=OFF ..
+```
+
+```
+make -j2
+```
+
+```
+cd ..
+```
+```
+sh ./create_root.sh
+```
+```
+cd/build
+```
+```
+sudo make install
+```
+```
+sudo ldconfig
+```
+
+
+>Note: There is no need to start the SoapySDR service! Instead we will use the SDR++ Server. For gnu-radio the Soapy server is needed though...
+
+###Desktop version SDR++
+Before the `soapy_source` is available it needs to be added, in the ‘Module Manager’ of SDR++ if you are running the desktop app on the Pi4. In the 'module manager' select ‘soapy_source’, add a name to the left e.g. ‘Soapy Source’ and click on the tiny plus sign on the right…
+
+Or...
+
+###Headless version SDR++
+If you are working from the cli you need to first run SDR++ so that the default config files are created.
+
+```
+sdrpp --server
+```
+Hit ^c to stop the server again.
+
+Edit the `~/.config/sdrpp/config.json` and add the soapy_source module:
+
+```
+        ,
+        "Soapy Source": {
+            "enabled": true,
+            "module": "soapy_source"
+        }
+```
+
+>Note: mind the comma above the double quote!
+
+Save the file and start the SDR++ server.
+
+```
+sdrpp --server
+```
+When the server starts watch the cli output and confirm that the 'Soapy Source' is loaded.
+
+On your remote computer you should now start SDR++ and select SDR++ Server as Source. Provide the correct IP address of the Pi running the SDR++ server. Press `Connect`. At the `Source [REMOTE]` use the drop down menu to select `SoapySDR`. You ay have to press the `Refresh` button first. In the dropdown menu below that make sure you select the device appropriate for your selected frequency.
+
+>Observations: The Pi4 can easily handle 4 MSPS but somehow when the `bandwidth` setting is set to `auto` there is no data coming from the radio. When the bandwidth setting is changed to 2 MHz data is streaming again. However the display bandwidth is 4 MHz! Is this a bug or a wrong `config` somewhere? 
+
+#TO DO: GNU-RADIO

--- a/ADDITIONAL-README.md
+++ b/ADDITIONAL-README.md
@@ -94,7 +94,7 @@ In both repositories run the below commands to build and install SoapySDR and So
 
 ```
 mkdir build && cd build
-cmake ..
+cmake .. -DENABLE_PYTHON3=ON
 make -j`nproc`
 sudo make install -j`nproc`
 sudo ldconfig #needed on debian systems

--- a/ADDITIONAL-README.md
+++ b/ADDITIONAL-README.md
@@ -350,12 +350,77 @@ FF E0 FF D2 C0 12 C0 1A  C0 DA FF 02 C0 00 C0 EE  |  ................
 C0 C0 C0 C4 C0 FA C0 E6  C0 30 C0 22 C0 C0 C0 CC  |  .........0.".... 
 05-01 14:00:45.055   644   648 E CARIBOULITE Radio cariboulite_radio_read_samples@cariboulite_radio.c:1276 SMI data synchronization failed
 ```
-
->~~~This is caused by the Pi0 not being able to handle 4 MSPS. During the configuration of SoapyRemote or SDR++ server we shall change this to 2 MSPS.~~~ 
-
 >I have just discovered that this behaviour is in fact due to a defective cariboulite board. It appears to function normally until you try to start the smi stream. Wait on feedback fromCaribouLabs. (May 1st 2025)
 
-> Also the Pi0 can do 4 MSPS if the data type is set CS8 instead of CS16 or CF32.   
+#feature/nbfm_rx
+If you decide to checkout the feature/nbfm_rx the menu after running cariboulite_test_app (I usualy run the app like this: ``` build/cariboulite_test_app 2> debug.log``` from the ```cariboulite``` directory, so that all debug logging goes to ```debug.log```) should look like this:
+```
+	   ____           _ _                 _     _ _         
+	  / ___|__ _ _ __(_) |__   ___  _   _| |   (_) |_ ___   
+	 | |   / _` | '__| | '_ \ / _ \| | | | |   | | __/ _ \  
+	 | |__| (_| | |  | | |_) | (_) | |_| | |___| | ||  __/  
+	  \____\__,_|_|  |_|_.__/ \___/ \__,_|_____|_|\__\___|  
+
+
+ Select a function:
+ [ 0]  Hard reset FPGA
+ [ 1]  Soft reset FPGA
+ [ 2]  Print board info and versions
+ [ 3]  Program FPGA
+ [ 4]  Perform a Self-Test
+ [ 5]  FPGA Digital I/O
+ [ 6]  FPGA RFFE control
+ [ 7]  FPGA SMI fifo status
+ [ 8]  Modem transmit CW signal
+ [ 9]  Modem receive I/Q stream
+ [10]  Synthesizer 85-4200 MHz
+ [11]  NBFM TX Tone
+ [12]  NBFM RX
+ [13]  NBFM modem Self-Test
+ [14]  Monitor Modem Status
+ [99]  Quit
+    Choice:   
+
+```
+>note: for the options 12 and 14 (R) to work correctly you need to have an audio device attached and configured correctly. It uses ALSA and some of these settings are hard-coded. This is WIP. 14 (T) TX tone should work though, transmitting a 650Hz tone, FM modulated on 430.100 MHz.
+
+This is how the monitor modem status output should look like:
+```
+CaribouLite Radio    [T]=TX ON/OFF  [R]=RX ON/OFF  [Q]=QUIT  [X]=RES  1766328674
+    TX Loopback: off    TX Frequency: 430100000 Hz    TX Power: -3 d     0.00361
+Modem Status Registers:
+    RF_CFG:0x08  RF_CLKO:0x1A
+    IQIFC0:0x33  IQIFC1:0x11  IQIFC2:0x0B
+    RF09-RXFDE :0x81  RF24-RXDFE :0x81
+    RF09-TXFDE :0x81  RF24-TXDFE :0x81
+    RF09-PADFE :0x40  RF24-PADFE :0x40
+    RF09-PAC   :0x6B  RF24-PAC   :0x72
+    RF09-IRQM  :0x3F  RF24-IRQM  :0x3F
+    RF09-IQRS  :0x00  RF24-IRQS  :0x00
+    RF09-STATE :0x02  RF24-STATE :0x02
+    RF09-TXDACI:0x7E  RF24-TXDACI:0x00
+    RF09-TXDACQ:0x3F  RF24-TXDACQ:0x00
+FPGA SMI info (0x05):
+    RX FIFO EMPTY: 1
+    TX FIFO FULL : 0
+    SMI CHANNEL  : 1    // 0=RX09 1=RX24
+    SMI DIRECTION: 0    // 0=TX   1=RX
+    DEBUG = 0, MODE: 'Low Power (0)'
+IQ Data Stream:
+    TX_I:0x00000FA1  TX_Q:0x00000013
+    RX_I:0x00000000  RX_Q:0x00000000
+Linux TX FIFO:
+    depth: 64/64 (100%), min:64 max:64
+    puts:64 gets:0 drops:0 tO_put:0 tO_get:0
+    rate: puts 0.0/s, gets 0.0/s  (expect ~100 fps @ 10ms)
+Linux RX FIFO:
+    depth: 0/128 (0%), min:128 max:0
+    puts:0 gets:0 drops:0 tO_put:0 tO_get:0
+    rate: puts 0.0/s, gets 0.0/s  (expect ~100 fps @ 10ms)
+```
+with ```T``` you enable TX (650 Hz tone) with ```R``` you enable RX. 
+
+>Caution! There is no squelch yet so, when no carrier is present, loud noise is emitted from the speaker or headphones! Redude your volume before you try this!   
 
 ###Increase the swapfile size
 During the SDR++ build `make` ran out of memory. Hence I increased the swap file from 512 to 1024.

--- a/ADDITIONAL-README.md
+++ b/ADDITIONAL-README.md
@@ -215,6 +215,13 @@ Then Hit Ctl+W and type ‘smi_stream_dev_remove’ and change the line with the
  }
 ```
 
+Instead of making the changes above yourself, you could also 'checkout' one of my recent feature branches, that has these chnages applied already. In addtion you get my 'Monitor Modem Status and NBFM TX and RX options:
+
+```
+cd ~/src/cariboulite
+git checkout feature/nbfm_rx
+```
+
 In the `cariboulite/driver` directory:
 
 ```

--- a/ADDITIONAL-README.md
+++ b/ADDITIONAL-README.md
@@ -382,6 +382,8 @@ If you decide to checkout the feature/nbfm_rx the menu after running cariboulite
     Choice:   
 
 ```
+>note: when the ```cariboulite_test_app```is started, it loads the fpga with the original firmware. This firmware has no TX path! To use the TX options you need to upload the updated firmware first, that is part of the feature/nbfm_tx_tone and/or feature/nbfm_rx branches. You can do this by executing option 0 (Hard reset FPGA) and option 3 (Program FPGA).
+
 >note: for the options 12 and 14 (R) to work correctly you need to have an audio device attached and configured correctly. It uses ALSA and some of these settings are hard-coded. This is WIP. 14 (T) TX tone should work though, transmitting a 650Hz tone, FM modulated on 430.100 MHz.
 
 This is how the monitor modem status output should look like:
@@ -429,7 +431,7 @@ During the SDR++ build `make` ran out of memory. Hence I increased the swap file
 sudo dphys-swapfile swapoff  
 sudo nano /etc/dphys-swapfile 
 ```
-Chnage the line `CONF_SWAPSIZE=512` to `CONF_SWAPSIZE=1024`. Save the file.
+Change the line `CONF_SWAPSIZE=512` to `CONF_SWAPSIZE=1024`. Save the file.
 
 ```
 sudo dphys-swapfile setup

--- a/ADDITIONAL-README.md
+++ b/ADDITIONAL-README.md
@@ -449,7 +449,7 @@ Install dependencies for SDR++:
 sudo apt install libglfw3 // maybe  not needed.
 sudo apt install libglfw3-dev
 sudo apt install libfftw3-dev
-sudo apt install libvolk-dev
+sudo apt install libvolk-dev // libvolk2-dev for bookworm?
 sudo apt install libvolk-bin
 sudo apt install libzstd-dev
 sudo apt install librtaudio-dev

--- a/ADDITIONAL-README.md
+++ b/ADDITIONAL-README.md
@@ -449,7 +449,8 @@ Install dependencies for SDR++:
 sudo apt install libglfw3 // maybe  not needed.
 sudo apt install libglfw3-dev
 sudo apt install libfftw3-dev
-sudo apt install libvolk2-dev
+sudo apt install libvolk-dev
+sudo apt install libvolk-bin
 sudo apt install libzstd-dev
 sudo apt install librtaudio-dev
 ```
@@ -457,7 +458,7 @@ sudo apt install librtaudio-dev
 or in one go:
 
 ```
-sudo apt install libglfw3-dev libfftw3-dev libvolk2-dev libzstd-dev librtaudio-dev
+sudo apt install libglfw3-dev libfftw3-dev libvolk-dev libvolk-bin libzstd-dev librtaudio-dev
 
 ```
 ### Install via the nightly build package

--- a/ADDITIONAL-README.md
+++ b/ADDITIONAL-README.md
@@ -234,7 +234,14 @@ Then in the cariboulite directory:
 ```
 ./install.sh
 ```
-This takes ‘a while’ on a Pi0. At a certain point the script will ask if you want to `install SoapySDR`, if you did not install it before. Say `Yes`. After the script has completed, reboot the Pi. Now we need to check with SMI driver is working correctly.
+This takes ‘a while’ on a Pi0. At a certain point the script will ask if you want to `install SoapySDR`, if you did not install it before. Say `Yes`. 
+
+After the script has completed, reboot the Pi. 
+```
+sudo reboot
+```
+
+Now we need to check with SMI driver is working correctly.
 
 ```
 lsmod | grep smi

--- a/ADDITIONAL-README.md
+++ b/ADDITIONAL-README.md
@@ -3,6 +3,7 @@ All of the steps for Bookworm still apply, however there was a policy change wit
 - mlock
 - RT scheduling
 - unprivileged DMA-style workloads
+
 Therefore some addtional steps on Trixie are required so that the cariboulite_test_app will run without the sudo -E option.
 
 ##Step 1

--- a/ADDITIONAL-README.md
+++ b/ADDITIONAL-README.md
@@ -1,3 +1,52 @@
+#Install CaribouLite with Raspberry pi OS Trixie (64bit) [WIP]
+All of the steps for Bookworm still apply, however there was a policy change with Debian 13 that tightend defaults for
+- mlock
+- RT scheduling
+- unprivileged DMA-style workloads
+Therefore some addtional steps on Trixie are required so that the cariboulite_test_app will run without the sudo -E option.
+
+##Step 1
+```
+bash
+
+sudo mkdir -p /etc/systemd/system.conf.d
+```
+```
+bash
+
+sudo tee /etc/systemd/system.conf.d/99-memlock.conf >/dev/null <<'EOF'
+[Manager]
+DefaultLimitMEMLOCK=infinity
+EOF
+```
+##Step 2
+```
+bash
+
+sudo mkdir -p /etc/systemd/user.conf.d
+```
+```
+bash
+
+sudo tee /etc/systemd/user.conf.d/99-memlock.conf >/dev/null <<'EOF'
+[Manager]
+DefaultLimitMEMLOCK=infinity
+EOF
+```
+##Step 3
+```
+bash
+
+sudo reboot
+```
+##Step 4
+```
+bash
+
+ulimit -l
+cat /proc/self/limits | grep -i "Max locked memory"
+```
+
 #Install CaribouLite with Raspberry Pi OS Bookworm (Lite) (64bit)
 
 My goal is to install the cariboulite on a Raspberry Pi0_2W and/or a Pi4. Requirements:  

--- a/ADDITIONAL-README.md
+++ b/ADDITIONAL-README.md
@@ -46,7 +46,7 @@ Save the file and reboot
 ###Install linux kernel header files:
 
 ```sudo apt install linux-headers-rpi-v8```
->Note: I think this step is only required if you want build SDR++.
+>Note: I think this step is required when you have to rebuild the smi driver and if you want build SDR++.
 
 ###Monitoring the Pi's activity
 The next steps will often take a while, during which you might want to periodically check that everything is still moving along.
@@ -84,7 +84,7 @@ Or:
 git clone https://github.com/Habraken/SoapySDR.git
 git clone https://github.com/Habraken/SoapyRemote.git
 ```
-The following library is not available by default and SoapyRemakemote will complain but not fail:
+The following library not available by default and SoapyRemakemote will complain but not fail:
 
 ```
 sudo apt install libavahi-client-dev
@@ -118,6 +118,12 @@ Or if you don't want to patch yourself:
 
 ```
 git clone https://github.com/Habraken/cariboulite.git
+```
+
+To make the nbfm_tx and nbfm_rx examples work you also need to install the dev tools for ALSA:
+
+```
+sudo apt install -y libasound2-dev pkg-config
 ```
 
 Before you can install anything make the following three changes to `~/src/cariboulite/driver/smi_stream_dev.c`.

--- a/driver/smi_stream_dev.c
+++ b/driver/smi_stream_dev.c
@@ -62,6 +62,7 @@
 #include <linux/wait.h>
 #include <linux/poll.h>
 #include <linux/init.h>
+#include <linux/vmalloc.h>
 
 #include "smi_stream_dev.h"
 
@@ -1050,7 +1051,7 @@ static int smi_stream_dev_probe(struct platform_device *pdev)
     }
 
     // Create sysfs entries with "smi-stream-dev"
-    smi_stream_class = class_create(THIS_MODULE, DEVICE_NAME);
+    smi_stream_class = class_create(DEVICE_NAME);
     ptr_err = smi_stream_class;
     if (IS_ERR(ptr_err))
     {
@@ -1102,7 +1103,7 @@ static int smi_stream_dev_probe(struct platform_device *pdev)
 *
 ***************************************************************************/
 
-static int smi_stream_dev_remove(struct platform_device *pdev)
+static void smi_stream_dev_remove(struct platform_device *pdev)
 {
     //if (inst->reader_thread != NULL) kthread_stop(inst->reader_thread);
     //inst->reader_thread = NULL;	
@@ -1113,7 +1114,6 @@ static int smi_stream_dev_remove(struct platform_device *pdev)
     unregister_chrdev_region(smi_stream_devid, 1);
 
     dev_info(inst->dev, DRIVER_NAME": smi-stream dev removed");
-    return 0;
 }
 
 /****************************************************************************


### PR DESCRIPTION
Minor changes so that the SMI driver compiles properly. Tested on both Raspberry Pi4 and Pi0, Running on an update 64bit version of the Raspberry PI OS: Bookworm.